### PR TITLE
chore: Bump GitHub Actions to Node 24-compatible majors [DMPLAT-1162]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: 3.9
       - name: Install dependencies


### PR DESCRIPTION
Bump GitHub Actions to their latest Node 24-compatible major versions. Trivial major-tag bumps only; no other workflow changes.

- actions/setup-python v4 -> v6

[DMPLAT-1162](https://g2crowd.atlassian.net/browse/DMPLAT-1162)

[DMPLAT-1162]: https://g2crowd.atlassian.net/browse/DMPLAT-1162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ